### PR TITLE
Shorten retrievals and serialize logs

### DIFF
--- a/pdata_app/tests/test_common.py
+++ b/pdata_app/tests/test_common.py
@@ -15,7 +15,7 @@ from pdata_app.utils.common import (make_partial_date_time,
                                     standardise_time_unit,
                                     calc_last_day_in_month, pdt2num,
                                     is_same_gws, get_request_size,
-                                    date_filter_files)
+                                    date_filter_files, grouper)
 from pdata_app.utils import dbapi
 from vocabs.vocabs import STATUS_VALUES, FREQUENCY_VALUES, VARIABLE_TYPES
 
@@ -313,6 +313,28 @@ class TestDateFilterFiles(TestCase):
         self.assertEqual(['test4', 'test8'],
                          _assertable(date_filter_files(data_files,
                                                        1975, 1985)))
+
+
+class TestGrouper(TestCase):
+    def test_exact_multiple(self):
+        actual = [list(chunk) for chunk in grouper(range(8), 4)]
+        expected = [[0, 1, 2, 3], [4, 5, 6, 7]]
+        self.assertEqual(actual, expected)
+
+    def test_non_exact_multiple(self):
+        actual = [list(chunk) for chunk in grouper(range(10), 4)]
+        expected = [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9]]
+        self.assertEqual(actual, expected)
+
+    def test_n_is_one(self):
+        actual = [list(chunk) for chunk in grouper(range(3), 1)]
+        expected = [[0], [1], [2]]
+        self.assertEqual(actual, expected)
+
+    def test_other_type(self):
+        actual = [list(chunk) for chunk in grouper(list(range(10)), 4)]
+        expected = [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9]]
+        self.assertEqual(actual, expected)
 
 
 def _make_example_files(parent_obj):

--- a/pdata_app/utils/common.py
+++ b/pdata_app/utils/common.py
@@ -4,6 +4,7 @@ common.py - several functions that are used throughout the pdata_app
 from __future__ import unicode_literals, division, absolute_import
 
 import datetime
+from itertools import zip_longest
 import logging
 import os
 import random
@@ -446,3 +447,21 @@ def delete_drs_dir(directory, mip_eras=('PRIMAVERA', 'CMIP6')):
             not directory.endswith(mip_eras)):
         # parent is empty so delete it
         delete_drs_dir(parent_dir)
+
+
+def grouper(iterable, n):
+    """
+    Group an iterable into chunks of length `n` with the final chunk containing
+    any remaining values and so possibly being less than length n.
+
+    Taken from:
+    https://docs.python.org/3.6/library/itertools.html#itertools-recipes
+
+    :param Iterable iterable: the input iterable to chunk
+    :param int n: return chunks of this length
+    :returns: iterables of length n
+    :rtype: Iterable
+    """
+    args = [iter(iterable)] * n
+    for chunk in zip_longest(*args):
+        yield filter(lambda x: x is not None, chunk)

--- a/pdata_app/utils/common.py
+++ b/pdata_app/utils/common.py
@@ -4,12 +4,12 @@ common.py - several functions that are used throughout the pdata_app
 from __future__ import unicode_literals, division, absolute_import
 
 import datetime
-from itertools import zip_longest
 import logging
 import os
 import random
 import re
 from subprocess import check_output, CalledProcessError
+from six.moves import zip_longest
 from tempfile import gettempdir
 
 from iris.time import PartialDateTime

--- a/scripts/retrieve_request.py
+++ b/scripts/retrieve_request.py
@@ -49,13 +49,9 @@ logger = logging.getLogger(__name__)
 
 # The top-level directory to write output data to
 BASE_OUTPUT_DIR = Settings.get_solo().base_output_dir
-# The name of the directory to store et_get.py log files in
-LOG_FILE_DIR = '/gws/nopw/j04/primavera5/.et_logs/'
-# The prefix to use on et_get.py log files
-LOG_PREFIX = 'et_get'
 # The number of processes that et_get.py should use.
 # Between 5 and 10 are recommended
-MAX_ET_GET_PROC = 10
+MAX_ET_GET_PROC = 5
 # The maximum number of retrievals to run in parallel
 MAX_TAPE_GET_PROC = 5
 
@@ -286,8 +282,8 @@ def get_et_url(tape_url, data_files, args):
 
     logger.debug('Restoring to {}'.format(retrieval_dir))
 
-    cmd = ('/usr/bin/python /usr/bin/et_get.py -l {} -f {} -r {} -t {}'.
-        format(_make_logfile_name(LOG_FILE_DIR), filelist_name, retrieval_dir,
+    cmd = ('/usr/bin/python /usr/bin/et_get.py -f {} -r {} -t {}'.
+        format(filelist_name, retrieval_dir,
         MAX_ET_GET_PROC))
 
     logger.debug('et_get.py command is:\n{}'.format(cmd))
@@ -412,22 +408,6 @@ def _check_file_checksum(data_file, file_path):
                checksum_obj.checksum_type, checksum_obj.checksum_value))
         logger.warning(msg)
         raise ChecksumError(msg)
-
-
-def _make_logfile_name(directory=None):
-    """
-    From the current date and time make a filename for a log-file.
-
-    :param str directory: The optional directory path to prepend to the
-        generated filename
-    :returns: The name of a log file to use
-    """
-    time_str = datetime.datetime.utcnow().strftime('%Y%m%d%H%M%S')
-    filename = '{}_{}.txt'.format(LOG_PREFIX, time_str)
-    if directory:
-        return os.path.join(directory, filename)
-    else:
-        return filename
 
 
 def _run_command(command):


### PR DESCRIPTION
Reduce the length of the command line for MASS retrievals to keep under shell limits. Don't write ET retrieval logs as these are done in parallel and hang the file system.