### PR TITLE
Corrected terminology

### DIFF
--- a/scripts/make_rose_task_names.py
+++ b/scripts/make_rose_task_names.py
@@ -69,16 +69,17 @@ def main(args):
     hadgem3_gc31_lm_amip_amon = DataRequest.objects.filter(
         climate_model__short_name='HadGEM3-GC31-LM',
         experiment__short_name='highresSST-present',
-        variant_label='r1i1p1f1',
+        rip_code='r1i1p1f1',
         variable_request__table_name='Amon',
         datafile__isnull=False
     ).distinct()
 
+    # task querysets can be ORed together with |
     all_tasks = hadgem3_gc31_lm_amip_amon
     task_name_list = [
         '{}_{}_{}_{}_{}'.format(dr.climate_model.short_name,
                                 dr.experiment.short_name,
-                                dr.variant_label,
+                                dr.rip_code,
                                 dr.variable_request.table_name,
                                 dr.variable_request.cmor_name)
         for dr in all_tasks


### PR DESCRIPTION
Use `rip_code` rather than `variant_label`, which is required for the DMT.