### PR TITLE
Fix attribute_update classes to work correctly on just updating files

### DIFF
--- a/pdata_app/tests/common.py
+++ b/pdata_app/tests/common.py
@@ -105,6 +105,7 @@ def make_example_files(parent_obj):
                                incoming_directory='/some/dir',
                                directory='/some/dir', user=parent_obj.user)
     parent_obj.data_file1 = dbapi.get_or_create(models.DataFile, name='test1',
+                                     incoming_name='test1',
                                      incoming_directory='/some/dir',
                                      directory='/some/dir1', size=1,
                                      project=project,
@@ -122,6 +123,7 @@ def make_example_files(parent_obj):
                                      time_units='days since 1950-01-01',
                                      version='v12345678')
     data_file4 = dbapi.get_or_create(models.DataFile, name='test4',
+                                     incoming_name='test4',
                                      incoming_directory='/some/dir',
                                      directory='/some/dir2', size=4,
                                      project=project,
@@ -138,6 +140,7 @@ def make_example_files(parent_obj):
                                      calendar='360_day',
                                      time_units='days since 1950-01-01')
     data_file8 = dbapi.get_or_create(models.DataFile, name='test8',
+                                     incoming_name='test8',
                                      incoming_directory='/some/dir',
                                      directory='/some/dir2', size=8,
                                      project=project,
@@ -154,6 +157,7 @@ def make_example_files(parent_obj):
                                      calendar='360_day',
                                      time_units='days since 1950-01-01')
     data_file2 = dbapi.get_or_create(models.DataFile, name='test2',
+                                     incoming_name='test2',
                                      incoming_directory='/some/dir',
                                      directory='/some/dir', size=2,
                                      project=project,

--- a/scripts/update_dreqs/update_dreqs_0181.py
+++ b/scripts/update_dreqs/update_dreqs_0181.py
@@ -64,6 +64,10 @@ def main(args):
             new_source_id = 'MPI-ESM1-2-HR'
         elif data_file.climate_model.short_name == 'MPIESM-1-2-XR':
             new_source_id = 'MPI-ESM1-2-XR'
+        elif data_file.climate_model.short_name == 'MPI-ESM1-2-HR':
+            new_source_id = 'MPI-ESM1-2-HR'
+        elif data_file.climate_model.short_name == 'MPI-ESM1-2-XR':
+            new_source_id = 'MPI-ESM1-2-XR'
         elif data_file.climate_model.short_name == 'EC-Earth3':
             new_source_id = 'EC-Earth3P'
         elif data_file.climate_model.short_name == 'EC-Earth3-HR':

--- a/scripts/update_dreqs/update_dreqs_0181.py
+++ b/scripts/update_dreqs/update_dreqs_0181.py
@@ -34,6 +34,9 @@ def parse_args():
     parser = argparse.ArgumentParser(description='Add additional data requests')
     parser.add_argument('-l', '--log-level', help='set logging level to one of '
         'debug, info, warn (the default), or error')
+    parser.add_argument('-i', '--incoming', help='Update file only, not the '
+                                                 'database.',
+                        action='store_true')
     parser.add_argument('request_id', help='to request id to update')
     parser.add_argument('--version', action='version',
         version='%(prog)s {}'.format(__version__))
@@ -92,7 +95,8 @@ def main(args):
         if created:
             logger.debug('Created {}'.format(new_dreq))
 
-        updater = SourceIdUpdate(data_file, new_source_id)
+        updater = SourceIdUpdate(data_file, new_source_id,
+                                 update_file_only=args.incoming)
         updater.update()
 
 

--- a/test/test_attribute_update.py
+++ b/test/test_attribute_update.py
@@ -109,8 +109,12 @@ class TestSourceIdUpdate(TestCase):
         self.mock_run_cmd.assert_has_calls(calls)
 
     @mock.patch('pdata_app.utils.attribute_update.DmtUpdate._check_available')
+    @mock.patch('pdata_app.utils.attribute_update.DmtUpdate.'
+                '_update_database_attribute')
+    @mock.patch('pdata_app.utils.attribute_update.DmtUpdate._rename_file')
     @mock.patch('pdata_app.utils.attribute_update.DmtUpdate._update_checksum')
-    def test_update_file_only(self, mock_checksum, mock_available):
+    def test_update_file_only(self, mock_checksum, mock_rename, mock_db_change,
+                              mock_available):
         updater = SourceIdUpdate(self.test_file, self.desired_source_id, True)
         updater.update()
         calls = [
@@ -124,6 +128,7 @@ class TestSourceIdUpdate(TestCase):
                       "var1_table_model_expt_varlab_gn_1-2.nc"),
         ]
         self.mock_run_cmd.assert_has_calls(calls)
+        mock_db_change.assert_not_called()
 
     @mock.patch('pdata_app.utils.attribute_update.DmtUpdate._check_available')
     @mock.patch('pdata_app.utils.attribute_update.DmtUpdate._rename_file')
@@ -359,6 +364,7 @@ def _make_files_realistic():
     """
     datafile = DataFile.objects.get(name='test1')
     datafile.name = 'var1_table_model_expt_varlab_gn_1-2.nc'
+    datafile.incoming_name = datafile.name
     datafile.directory = '/gws/nopw/j04/primavera9/stream1/path'
     datafile.save()
     Checksum.objects.create(data_file=datafile, checksum_value='1234567890',


### PR DESCRIPTION
Fix attribute_update classes to work correctly on just updating files and not the database. This is useful when rerunning.